### PR TITLE
fix: add missing includes

### DIFF
--- a/src/CryptoNoteCore/Blockchain.cpp
+++ b/src/CryptoNoteCore/Blockchain.cpp
@@ -28,6 +28,7 @@
 // 
 // Parts of this file are originally copyright (c) 2012-2016 The Cryptonote developers
 
+#include <cstring>
 #include "Blockchain.h"
 
 #include <algorithm>

--- a/src/Platform/Linux/System/Dispatcher.cpp
+++ b/src/Platform/Linux/System/Dispatcher.cpp
@@ -29,6 +29,7 @@
 // Parts of this file are originally copyright (c) 2012-2016 The Cryptonote developers
 
 #include "Dispatcher.h"
+#include <pthread.h>
 #include <cassert>
 #include <cstdint> //dm
 #include <stdexcept> //dm


### PR DESCRIPTION
without that the project did not build on my maschine (Fedora 36)