### PR TITLE
fix: simplewallet legacy keys storage string include

### DIFF
--- a/src/WalletLegacy/KeysStorage.h
+++ b/src/WalletLegacy/KeysStorage.h
@@ -40,6 +40,7 @@
 #include "crypto/crypto.h"
 
 #include <stdint.h>
+#include <string>
 
 namespace DynexCN {
 


### PR DESCRIPTION
build failed due to missing string include in the wallet legacy keys storage:

```
make SimpleWallet -j 8
...
src/WalletLegacy/KeysStorage.cpp:47:6: error: no declaration matches ‘void DynexCN::KeysStorage::serialize(DynexCN::ISerializer&, const std::string&)’
```